### PR TITLE
Add block utilities and unit tests

### DIFF
--- a/client/src/components/workbench/CanvasWorkspace.tsx
+++ b/client/src/components/workbench/CanvasWorkspace.tsx
@@ -15,6 +15,11 @@ import ReactFlow, {
   Position,
 } from "reactflow";
 import { useWorkbenchStore } from "@/store/workbench";
+import {
+  getSubtitleForTool,
+  getBlockTypeFromLabel,
+  getPropertiesFromSubtitle,
+} from "@/lib/block-utils";
 
 // Custom node component with standard control system symbols
 function ControlBlock({ data }: { data: any }) {
@@ -375,82 +380,4 @@ export default function CanvasWorkspace() {
       </ReactFlow>
     </div>
   );
-}
-
-function getSubtitleForTool(tool: string): string {
-  switch (tool) {
-    case "pid-controller":
-      return "Kp=1, Ki=0.1, Kd=0.05";
-    case "transfer-function":
-      return "1/(s+1)";
-    case "gain-block":
-      return "K=1.0";
-    case "step-input":
-      return "Amp=1.0";
-    case "sine-wave":
-      return "f=1Hz";
-    default:
-      return "";
-  }
-}
-
-function getBlockTypeFromLabel(label: string): string {
-  return label.toLowerCase().replace(/\s+/g, "-");
-}
-
-function getPropertiesFromSubtitle(subtitle: string): any {
-  if (!subtitle) return {};
-
-  if (subtitle.includes("Kp=")) {
-    // Parse PID parameters
-    const kpMatch = subtitle.match(/Kp=([0-9.]+)/);
-    const kiMatch = subtitle.match(/Ki=([0-9.]+)/);
-    const kdMatch = subtitle.match(/Kd=([0-9.]+)/);
-
-    return {
-      kp: kpMatch ? parseFloat(kpMatch[1]) : 1,
-      ki: kiMatch ? parseFloat(kiMatch[1]) : 0.1,
-      kd: kdMatch ? parseFloat(kdMatch[1]) : 0.05,
-    };
-  }
-
-  if (subtitle.includes("/(") && subtitle.includes(")")) {
-    // Parse transfer function
-    const parts = subtitle.split("/");
-    if (parts.length === 2) {
-      const numerator = parts[0].trim();
-      const denominator = parts[1].replace(/[()]/g, "").trim();
-
-      return {
-        numerator: [numerator],
-        denominator: denominator.split("+").map((s) => s.trim()),
-      };
-    }
-  }
-
-  if (subtitle.includes("K=")) {
-    // Parse gain
-    const gainMatch = subtitle.match(/K=([0-9.]+)/);
-    return {
-      gain: gainMatch ? parseFloat(gainMatch[1]) : 1,
-    };
-  }
-
-  if (subtitle.includes("Amp=")) {
-    // Parse amplitude
-    const ampMatch = subtitle.match(/Amp=([0-9.]+)/);
-    return {
-      amplitude: ampMatch ? parseFloat(ampMatch[1]) : 1,
-    };
-  }
-
-  if (subtitle.includes("f=")) {
-    // Parse frequency
-    const freqMatch = subtitle.match(/f=([0-9.]+)/);
-    return {
-      frequency: freqMatch ? parseFloat(freqMatch[1]) : 1,
-    };
-  }
-
-  return {};
 }

--- a/client/src/lib/block-utils.test.ts
+++ b/client/src/lib/block-utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getSubtitleForTool,
+  getBlockTypeFromLabel,
+  getPropertiesFromSubtitle,
+} from './block-utils.js';
+
+// getSubtitleForTool tests
+describe('getSubtitleForTool', () => {
+  it('returns defaults for known tools', () => {
+    assert.equal(getSubtitleForTool('pid-controller'), 'Kp=1, Ki=0.1, Kd=0.05');
+    assert.equal(getSubtitleForTool('transfer-function'), '1/(s+1)');
+    assert.equal(getSubtitleForTool('gain-block'), 'K=1.0');
+  });
+});
+
+// getBlockTypeFromLabel tests
+describe('getBlockTypeFromLabel', () => {
+  it('converts label to kebab-case', () => {
+    assert.equal(getBlockTypeFromLabel('PID Controller'), 'pid-controller');
+  });
+});
+
+// getPropertiesFromSubtitle tests
+describe('getPropertiesFromSubtitle', () => {
+  it('parses PID parameters', () => {
+    const props = getPropertiesFromSubtitle('Kp=2, Ki=0.5, Kd=0.1');
+    assert.deepEqual(props, { kp: 2, ki: 0.5, kd: 0.1 });
+  });
+
+  it('parses transfer function', () => {
+    const props = getPropertiesFromSubtitle('1/(s²+2s+1)');
+    assert.deepEqual(props, {
+      numerator: ['1'],
+      denominator: ['s²', '2s', '1'],
+    });
+  });
+
+  it('parses gain', () => {
+    assert.deepEqual(getPropertiesFromSubtitle('K=3'), { gain: 3 });
+  });
+
+  it('parses amplitude', () => {
+    assert.deepEqual(getPropertiesFromSubtitle('Amp=2'), { amplitude: 2 });
+  });
+
+  it('parses frequency', () => {
+    assert.deepEqual(getPropertiesFromSubtitle('f=1Hz'), { frequency: 1 });
+  });
+
+  it('returns empty object for unknown', () => {
+    assert.deepEqual(getPropertiesFromSubtitle(''), {});
+  });
+});

--- a/client/src/lib/block-utils.ts
+++ b/client/src/lib/block-utils.ts
@@ -1,0 +1,72 @@
+export function getSubtitleForTool(tool: string): string {
+  switch (tool) {
+    case "pid-controller":
+      return "Kp=1, Ki=0.1, Kd=0.05";
+    case "transfer-function":
+      return "1/(s+1)";
+    case "gain-block":
+      return "K=1.0";
+    case "step-input":
+      return "Amp=1.0";
+    case "sine-wave":
+      return "f=1Hz";
+    default:
+      return "";
+  }
+}
+
+export function getBlockTypeFromLabel(label: string): string {
+  return label.toLowerCase().replace(/\s+/g, "-");
+}
+
+export function getPropertiesFromSubtitle(subtitle: string): any {
+  if (!subtitle) return {};
+
+  if (subtitle.includes("Kp=")) {
+    const kpMatch = subtitle.match(/Kp=([0-9.]+)/);
+    const kiMatch = subtitle.match(/Ki=([0-9.]+)/);
+    const kdMatch = subtitle.match(/Kd=([0-9.]+)/);
+
+    return {
+      kp: kpMatch ? parseFloat(kpMatch[1]) : 1,
+      ki: kiMatch ? parseFloat(kiMatch[1]) : 0.1,
+      kd: kdMatch ? parseFloat(kdMatch[1]) : 0.05,
+    };
+  }
+
+  if (subtitle.includes("/(") && subtitle.includes(")")) {
+    const parts = subtitle.split("/");
+    if (parts.length === 2) {
+      const numerator = parts[0].trim();
+      const denominator = parts[1].replace(/[()]/g, "").trim();
+
+      return {
+        numerator: [numerator],
+        denominator: denominator.split("+").map((s) => s.trim()),
+      };
+    }
+  }
+
+  if (subtitle.includes("K=")) {
+    const gainMatch = subtitle.match(/K=([0-9.]+)/);
+    return {
+      gain: gainMatch ? parseFloat(gainMatch[1]) : 1,
+    };
+  }
+
+  if (subtitle.includes("Amp=")) {
+    const ampMatch = subtitle.match(/Amp=([0-9.]+)/);
+    return {
+      amplitude: ampMatch ? parseFloat(ampMatch[1]) : 1,
+    };
+  }
+
+  if (subtitle.includes("f=")) {
+    const freqMatch = subtitle.match(/f=([0-9.]+)/);
+    return {
+      frequency: freqMatch ? parseFloat(freqMatch[1]) : 1,
+    };
+  }
+
+  return {};
+}


### PR DESCRIPTION
## Summary
- move helper functions for creating blocks into `lib/block-utils.ts`
- import those helpers in `CanvasWorkspace`
- add initial unit tests for the helpers

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68587666ae88832a8eb32a9bb78fbc36